### PR TITLE
Add Contributor Growth working group

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,13 @@ Facilitators:
 
 ### Contributor Growth  
 
-Status: [Proposed](issue link)
+
+* [Charter](/contributor-growth/README.md)
 
 Facilitators:
 
-- Carolyn Van Slyck, Microsoft
-- Paris Pittman, Google
+- Carolyn Van Slyck ([@carolynvs](https://github.com/carolynvs)), Microsoft
+- Paris Pittman ([@parispittman](https://github.com/parispittman)), Google
 
 
 ### Maintainer's Circle

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -1,7 +1,7 @@
 # Contributor Growth
 
-The Contributor Growth subproject is interested in assisting CNCF projects with
-sustainably growing their contributor base.
+The Contributor Growth working group is interested in assisting CNCF projects
+with sustainably growing their contributor base.
 
 ## Goals
 
@@ -21,7 +21,7 @@ sustainably growing their contributor base.
   maintainers guide, contribution ladder, etc.
 * Case studies of successful projects of various kinds/sizes and how they manage
   contributions.
-* Collect and share talks related to the subproject's mission, for example
+* Collect and share talks related to the working group's mission, for example
   building open source communities, or reflections on a particular community's
   best practices.
 * Document ways to contribute to a project, especially roles outside of the

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -1,0 +1,65 @@
+# Contributor Growth
+
+The Contributor Growth subproject is interested in assisting CNCF projects with
+sustainably growing their contributor base.
+
+## Goals
+
+* Provide best practices and resources for managing and interacting with
+  contributors to CNCF projects.
+* Provide guidance on building a contributor pipeline that brings in new
+  contributors and promotes them to higher levels of responsibility within CNCF
+  projects, including the maintainer role.
+
+## Scope
+
+* Templates for common documents like a contributing guide, reviewing guide,
+  maintainers guide, contribution ladder, etc.
+* Case studies of sucessful projects of various kinds/sizes and how they manage
+  contributions.
+* Collect and share talks related to the subproject's mission, for example
+  building open source communities, or reflections on a particular community's
+  best practices.
+* Document ways to contribute to a project, especially roles outside of the
+  obvious feature enhancement/code contributions.
+* Create spaces for maintainers of CNCF projects to share their own best
+  practices and ask questions.
+* Discuss non-code areas that support contributor growth, such as project
+  management, design, user experience and documentation and how CNCF projects
+  can prioritize work that may not be the maintainers primary skillset.
+* Provide materials that a CNCF project can use to address the TOC [due
+  dilligence guidelines] related to project's contributors and community.
+
+[due dilligence guidelines]: https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md#project
+
+### Out-of-Scope
+
+The following are exmaples of things out-of-scope:
+
+* Project governance.
+* Project automation, such as prow.
+* Day to day support for improving the contribution experience for CNCF
+  projects. That falls under other projects, for example Kubernetes SIG
+  Contributor Experience.
+
+## Members
+
+* Carolyn Van Slyck - [@carolynvs](https://github.com/carolynvs) (Lead)
+* Karen Chu - [@karenhchu](https://github.com/karenhchu)
+* Paris Pittman - [@parispittman](https://github.com/parispittman)
+
+Don't see your name? That was an oversight! Open a PR and add yourself. ❤️
+
+## Meetings
+
+Currently there are no scheduled meetings.  Discussion happens on the
+[mailing list] or on #sig-contributor-strategy on [Slack].
+
+[mailing list]: https://lists.cncf.io/g/cncf-sig-contributor-strategy
+[Slack]: https://slack.cncf.io/
+
+# Documentation
+
+Our documentation is shared in the [cncf/contribute] respository.
+
+[cncf/contribute]: https://github.com/cncf/contribute

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -26,8 +26,6 @@ with sustainably growing their contributor base.
   best practices.
 * Document ways to contribute to a project, especially roles outside of the
   obvious feature enhancement/code contributions.
-* Create spaces for maintainers of CNCF projects to share their own best
-  practices and ask questions.
 * Discuss non-code areas that support contributor growth, such as project
   management, design, user experience and documentation and how CNCF projects
   can prioritize work that may not be the maintainers primary skillset.

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -43,10 +43,8 @@ The following are examples of things out-of-scope:
 * Project governance.
 * Project automation, such as prow.
 * Day to day support for improving the contribution experience for CNCF
-  projects. Some CNCF projects have support for this, for example within
-  Kubernetes, that would be Kubernetes SIG Contributor Experience. Even when
-  there is not a relevant CNCF project these activities are out-of-scope
-  for this subproject.
+  projects. Instead, CNCF projects should take on this support themselves (for
+  example, Kubernetes has SIG Contributor Experience).
 
 ## Members
 

--- a/contributor-growth/README.md
+++ b/contributor-growth/README.md
@@ -7,15 +7,19 @@ sustainably growing their contributor base.
 
 * Provide best practices and resources for managing and interacting with
   contributors to CNCF projects.
-* Provide guidance on building a contributor pipeline that brings in new
-  contributors and promotes them to higher levels of responsibility within CNCF
-  projects, including the maintainer role.
+* Provide guidance on a sustainable contributor lifecycle for CNCF Projects to:
+  * Develop a pipeline that brings in new contributors.
+  * Define a contribution ladder with activities that promote contributors to
+    higher levels of responsibility.
+  * Support their maintainers with advice and resources that improve sustainability
+    and plan for transitions from the project.
+    
 
 ## Scope
 
 * Templates for common documents like a contributing guide, reviewing guide,
   maintainers guide, contribution ladder, etc.
-* Case studies of sucessful projects of various kinds/sizes and how they manage
+* Case studies of successful projects of various kinds/sizes and how they manage
   contributions.
 * Collect and share talks related to the subproject's mission, for example
   building open source communities, or reflections on a particular community's
@@ -28,19 +32,21 @@ sustainably growing their contributor base.
   management, design, user experience and documentation and how CNCF projects
   can prioritize work that may not be the maintainers primary skillset.
 * Provide materials that a CNCF project can use to address the TOC [due
-  dilligence guidelines] related to project's contributors and community.
+  diligence guidelines] related to project's contributors and community.
 
-[due dilligence guidelines]: https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md#project
+[due diligence guidelines]: https://github.com/cncf/toc/blob/master/process/due-diligence-guidelines.md#project
 
 ### Out-of-Scope
 
-The following are exmaples of things out-of-scope:
+The following are examples of things out-of-scope:
 
 * Project governance.
 * Project automation, such as prow.
 * Day to day support for improving the contribution experience for CNCF
-  projects. That falls under other projects, for example Kubernetes SIG
-  Contributor Experience.
+  projects. Some CNCF projects have support for this, for example within
+  Kubernetes, that would be Kubernetes SIG Contributor Experience. Even when
+  there is not a relevant CNCF project these activities are out-of-scope
+  for this subproject.
 
 ## Members
 
@@ -60,6 +66,6 @@ Currently there are no scheduled meetings.  Discussion happens on the
 
 # Documentation
 
-Our documentation is shared in the [cncf/contribute] respository.
+Our documentation is shared in the [cncf/contribute] repository.
 
 [cncf/contribute]: https://github.com/cncf/contribute


### PR DESCRIPTION
Makes the Contributor Growth working group official!

I wasn't sure who all is in the subproject, so if you don't see your name but think you are in the subproject. YOU ARE IN! 🙌 I just went by who had something assigned to them on #12. I can add you now in this PR, or you can PR yourself in later.

I am assuming that merging this PR will mean that the subproject was accepted. That's why I made the edit to the README at the same time. If that's not right, please let me know and I'll switch to marking it as proposed instead like the others.

Closes #12 