### PR TITLE
Use the term working group instead of subproject

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The [SIG Contributor Strategy charter](/CHARTER.md) outlines the scope of our gr
   - [SIG Chairs](#sig-chairs)
   - [TOC Liaisons](#toc-liaisons)
   - [Bootstrap SIG members](#bootstrap-sig-members)
-- [Subprojects](#subprojects)
+- [Working Groups](#working-groups)
   - [Governance](#governance)
   - [Maintainer's Circle](#maintainers-circle)
   - [GitHub Management](#github-management)
@@ -84,7 +84,7 @@ channels:
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), VMware
 - Zach Corleissen ([@zacharysarah](https://github.com/zacharysarah)), Linux Foundation
 
-## Subprojects
+## Working Groups
 
 ### Governance
 

--- a/github-mgmt/README.md
+++ b/github-mgmt/README.md
@@ -1,3 +1,3 @@
 # GitHub Management
 
-Placeholder for the GitHub Management subproject [proposed here](https://github.com/cncf/sig-contributor-strategy/issues/5).
+Placeholder for the GitHub Management working group [proposed here](https://github.com/cncf/sig-contributor-strategy/issues/5).

--- a/governance/README.md
+++ b/governance/README.md
@@ -1,10 +1,10 @@
 # Governance
 
-The Governance subproject of Contributor Strategy aims to assist all CNCF projects with implementing good open source governance practices.  If you are looking for the governance documents of SIG-Contributor-Strategy itself, please read CONTRIBUTING.md.
+The Governance working group of Contributor Strategy aims to assist all CNCF projects with implementing good open source governance practices.  If you are looking for the governance documents of SIG-Contributor-Strategy itself, please read CONTRIBUTING.md.
 
 If you are interested in helping with this project, please speak up on #sig-contributor-strategy in CNCF Slack, or on the mailing list.
 
-## Goals of the Subproject
+## Goals of the Working Group
 
 1. Create, share, and maintain documentation on implementing good open source governance for CNCF projects.
 2. Coach and advise CNCF projects, and prospective projects, leaders in implementing and improving governance.
@@ -12,7 +12,7 @@ If you are interested in helping with this project, please speak up on #sig-cont
 
 ## Scope
 
-The Governance subproject is focused on, and restricted to, matters related to CNCF project governance, defined as project participation roles, rules, and procedures.  For more information on what governance is, please see the [Governance Documentation](https://github.com/cncf/sig-contributor-strategy/tree/master/governance/docs). As examples, this would include issues like:
+The Governance working group is focused on, and restricted to, matters related to CNCF project governance, defined as project participation roles, rules, and procedures.  For more information on what governance is, please see the [Governance Documentation](https://github.com/cncf/sig-contributor-strategy/tree/master/governance/docs). As examples, this would include issues like:
 
 * Selection/election process for new Owners
 * How to make sure your meetings are really open
@@ -22,15 +22,15 @@ The Governance subproject is focused on, and restricted to, matters related to C
 * Online seminars on how to craft your project's governance
 * Reviewing, on request by the TOC, the governance for a project currently applying for membership/graduation
 
-The following are examples of things outside of the scope of this subproject:
+The following are examples of things outside of the scope of this working group:
 
-* Recruiting new contributors (this will be handled by Contributor Growth subproject)
+* Recruiting new contributors (this will be handled by Contributor Growth working group)
 * CNCF SIG governance (handled by the TOC)
 * Drafting legal documents for your project, or choosing a license (we're not attorneys)
 
-## Subproject Members
+## Working Group Members
 
-The following contributors are currently "members" of this subproject:
+The following contributors are currently "members" of this working group:
 
 * Josh Berkus (Lead)
 * April Kyle Nassi (Contributor)
@@ -39,7 +39,7 @@ Currently there are no scheduled meetings.  Discussion happens on the [contribut
 
 ## Directory
 
-Currently we have the following content in this subproject:
+Currently we have the following content in this working group:
 
 * **docs**: documents offering advice, processes, implementation details, and other information for project governance. Documents here are for the benefit of project leaders trying to improve their governance.
 * **draft-requirements**: directory of suggested changes to the CNCF requirements for project governance, with supporting materials.  Documents in this folder will be shared with the TOC when they revise the acceptance and diligence process.

--- a/maintainers-circle/README.md
+++ b/maintainers-circle/README.md
@@ -1,3 +1,3 @@
 # Maintainer's Circle
 
-Placeholder for the Maintainer's Circle subproject [proposed here](https://github.com/cncf/sig-contributor-strategy/issues/1).
+Placeholder for the Maintainer's Circle working group [proposed here](https://github.com/cncf/sig-contributor-strategy/issues/1).


### PR DESCRIPTION
Per the [TOC charter](https://github.com/cncf/toc/blob/master/sigs/cncf-sigs.md#responsibilities--empowerment-of-sigs), we use the term working group. I've updated any reference to subprojects to instead be working group.