### PR TITLE
Minor updates for governance references.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ channels:
 
 ### Governance
 
-Status: [Proposed](https://github.com/cncf/sig-contributor-strategy/issues/7)
+[Charter](/governance/README.md)
 
 Facilitators:
 

--- a/governance/README.md
+++ b/governance/README.md
@@ -38,7 +38,11 @@ The following contributors are currently "members" of this working group:
 * Jennifer Davis
 * Davanum Srinivas
 
-Currently there are no scheduled meetings.  Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-sig-contributor-strategy) or on #sig-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
+## Meetings
+
+Meetings take place every 1st and 3rd Tuesday at 10am PT.
+
+Discussion happens on the [contributor strategy mailing list](https://lists.cncf.io/g/cncf-sig-contributor-strategy) or on #sig-contributor-strategy on [CNCF slack](https://slack.cncf.io/).
 
 ## Directory
 


### PR DESCRIPTION
Removed the link to issue proposing the governance WG and replaced it with the governance README and called it our Charter, similar to what Contributor Growth has done.

Added our meeting time to the governance page.