### PR TITLE
Add staging website

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,19 @@
+name: Sync Staging
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  sync-staging:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Sync Staging
+        uses: devmasx/merge-branch@v1.3.1
+        with:
+          type: now
+          from_branch: master
+          target_branch: staging
+          github_token: ${{ github.token }}

--- a/magefile.go
+++ b/magefile.go
@@ -97,12 +97,21 @@ func Hugo() error {
 	return errors.Wrap(err, "could not start hugo in a container")
 }
 
+// Build the live website.
 func Deploy() error {
 	mg.Deps(docsy, syncGoMod)
 
 	return shx.RunV("hugo", "-s", "website", "--debug", "--verbose")
 }
 
+// Deploy branch builds the website, including future dated and draft posts
+func DeployBranch() error {
+	mg.Deps(docsy, syncGoMod)
+
+	return shx.RunV("hugo", "-s", "website", "--debug", "--buildDrafts", "--buildFuture", "--verbose", "-b", getBaseUrl())
+}
+
+// Deploy preview builds the website for a pull request, using the same build settings as the live site.
 func DeployPreview() error {
 	mg.Deps(docsy, syncGoMod)
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@
   HUGO_ENV = "production"
 
 [context.branch-deploy]
-  command = "go run mage.go -v DeployPreview"
+  command = "go run mage.go -v DeployBranch"
   
 [context.deploy-preview]
   command = "go run mage.go -v DeployPreview"


### PR DESCRIPTION
This does two things:
* Tells netlify that when it builds a branch that isn't the production branch, i.e. not master, that it should include drafts and future dated posts.
* Keeps a staging branch in sync with our production branch (master). So anytime we merge a pull request to master, that PR is automatically merged to the staging branch at the same time.

What this will do is give us a staging website that includes pages normally hidden on the live site, i.e. anything with `draft: true` or `date: FUTURE DATE`.

I think the staging URL will be https://staging--cncf-contribute.netlify.app but it won't be available until after we merge.