### PR TITLE
Include drafts in pull request previews

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -115,7 +115,7 @@ func DeployBranch() error {
 func DeployPreview() error {
 	mg.Deps(docsy, syncGoMod)
 
-	return shx.RunV("hugo", "-s", "website", "--debug", "--verbose", "-b", getBaseUrl())
+	return shx.RunV("hugo", "-s", "website", "--debug", "--buildDrafts", "--buildFuture", "--verbose", "-b", getBaseUrl())
 }
 
 func syncGoMod() error {


### PR DESCRIPTION
When a pull request is built by netlify, include drafts so that the PR
author can see what the site will look like with their change. Keep in
mind that even though they will see drafts in the PR preview, on the
live site they will be hidden.

You should look at the [staging](https://staging--cncf-contribute.netlify.app) website to see draft documents on the
website.