### PR TITLE
Fix edit this page links

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -160,12 +160,12 @@ prism_syntax_highlighting = false
 # Repository configuration (URLs for in-page links to opening issues and suggesting changes)
 [params.github]
   repo = "https://github.com/cncf/sig-contributor-strategy"
-  branch = "website"
+  branch = "master"
   subdir = "website"
 
   [params.github.contributors]
-    repo = "https://github.com/carolynvs/cncf-contribute"
-    branch = "website"
+    repo = "https://github.com/cncf/contribute"
+    branch = "main"
 
 
 # User interface configuration


### PR DESCRIPTION
They were set up for when the site wasn't merged and I forgot to flip them over.